### PR TITLE
Add isBankHoliday function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,15 +227,22 @@ export function getBankHolidays(
   }, {});
 }
 
-export function isHoliday(date: Date, onlyBankHolidays = false): boolean {
-  const holidays = (onlyBankHolidays ? getBankHolidays : getHolidays)(getYear(date));
+function isInHolidayList(
+  date: Date,
+  getHolidayList: (year: number) => { [key: string]: { date: Date } }
+): boolean {
+  const holidays = getHolidayList(getYear(date));
   return (
     Object.keys(holidays).filter(holidayName => {
-      return isEqual(date, holidays[holidayName as Holiday].date);
+      return isEqual(date, holidays[holidayName].date);
     }).length > 0
   );
 }
 
+export function isHoliday(date: Date): boolean {
+  return isInHolidayList(date, getHolidays);
+}
+
 export function isBankHoliday(date: Date): boolean {
-  return isHoliday(date, true);
+  return isInHolidayList(date, getBankHolidays);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,11 +227,15 @@ export function getBankHolidays(
   }, {});
 }
 
-export function isHoliday(date: Date): boolean {
-  const holidays = getHolidays(getYear(date));
+export function isHoliday(date: Date, onlyBankHolidays = false): boolean {
+  const holidays = (onlyBankHolidays ? getBankHolidays : getHolidays)(getYear(date));
   return (
     Object.keys(holidays).filter(holidayName => {
       return isEqual(date, holidays[holidayName as Holiday].date);
     }).length > 0
   );
+}
+
+export function isBankHoliday(date: Date): boolean {
+  return isHoliday(date, true);
 }


### PR DESCRIPTION
Extends the `isHoliday` function to optionally only consider bank holidays, and exposes this new functionality directly via a `isBankHoliday` function